### PR TITLE
Add basic network checks

### DIFF
--- a/docs/cfg.rst
+++ b/docs/cfg.rst
@@ -103,3 +103,35 @@ Example::
         service-wrapper
         jolokia-jvm-agent
     """
+
+
+Network
+^^^^^^^
+
+The ``network`` plugin is able to check if all ports and addresses, that your
+server is going to use, are not already bound.
+
+Example (short-hand notation)::
+
+   [pre-check]
+
+   [[Network]]
+   ports = 80, 8081
+
+Example (verbose)::
+
+   [pre-check]
+
+   [[Network]]
+
+   [[[http]]]
+   port = 80
+   family = tcp
+   address = 0.0.0.0
+
+   [[[jmx_port]]]
+   port = 6379
+   family = tcp
+   address = 127.0.0.1
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 click>=3.3,<4
 colorama
-psutil==2.2.1
+psutil>=3.0
 
 bunch==1.0.1
 configobj>=5.0,<6

--- a/src/bootils/plugins/core/network.py
+++ b/src/bootils/plugins/core/network.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=bad-continuation
+""" Networking plugin.
+"""
+# Copyright ©  2015 1&1 Group <btw-users@googlegroups.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, unicode_literals, print_function
+
+import psutil
+
+from ..loader import PluginBase
+
+
+class Network(PluginBase):
+    """Networking checks."""
+
+    def _check(self):
+        """Perform checks."""
+
+        cfg = self.cfg[self.context.phase].get(self.name, {})
+        ports = cfg.get('ports')
+        if not ports:
+            return
+        if isinstance(ports, str) or isinstance(ports, unicode):
+            ports = [ports]
+
+        for port in ports:
+            yield self._result('inet', None, port)
+
+        for section in cfg.keys():
+            if section in ['ports']:
+                continue
+            scf = cfg[section]
+            yield self._result(scf.get('family', 'inet'), scf.get('address'), scf.get('port'), section)
+
+    def _result(self, family, address, port, service=""):
+        """Returns result on availability of specified socket."""
+
+        if address:
+            cmt = "Listening port {}:{}:{}".format(family, address, port)
+        else:
+            cmt = "Listening port {}::{}".format(family, port)
+        if service:
+            cmt = cmt + " ({})".format(service)
+
+        # check if socket is already bound
+        for conn in psutil.net_connections(kind=family):
+            if conn.status == psutil.CONN_LISTEN and (not address or conn.laddr[0] == address) \
+                    and conn.laddr[1] == int(port):
+                return self.result(False, "server_socket", cmt, diagnostics="Socket alread bound")
+
+        # check if interface exists
+        if address and address != '0.0.0.0':
+            found = False
+            for _, addrs in psutil.net_if_addrs().items():
+                for snic in addrs:
+                    if snic.address == address:
+                        found = True
+                        break
+            if not found:
+                return self.result(False, "server_socket", cmt, diagnostics="Interface for {} does not exist".format(address))
+
+        return self.result(True, "server_socket", cmt, diagnostics="Socket available")
+
+    pre_check = _check

--- a/src/bootils/plugins/core/network.py
+++ b/src/bootils/plugins/core/network.py
@@ -32,8 +32,10 @@ class Network(PluginBase):
         ports = cfg.get('ports')
         if not ports:
             return
-        if isinstance(ports, str) or isinstance(ports, unicode):
-            ports = [ports]
+        try:
+            ports = [ports + '']
+        except (TypeError, ValueError):
+            pass # ports already iterable
 
         for port in ports:
             yield self._result('inet', None, port)


### PR DESCRIPTION
This PR will add some checks to make sure that certain ports are not already bound by another process. 

Please note that using subsections - as described in the docs - from a module's config is currently not possible. I had to disable the "Remove unrelated subsections" part from `PluginExecutor.configure()` to make it work.
